### PR TITLE
Cache loaded N5 blocks for label lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /target
 *.swp
 *_completion
+.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+dist: trusty
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>label-utilities</artifactId>
-            <version>0.4.3-SNAPSHOT</version>
+            <version>0.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
@@ -74,11 +74,14 @@
 
 
 	<properties>
+		<package-name>org.janelia.saalfeldlab</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<imglib2-cache.version>1.0.0-beta-13</imglib2-cache.version>
 	</properties>
 
 	<repositories>
@@ -100,7 +103,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>label-utilities</artifactId>
-            <version>0.4.2</version>
+            <version>0.4.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
@@ -124,6 +124,7 @@ class LabelBlockLookupFromN5(
 		val mapByBlockKey = mutableMapOf<N5LabelBlockLookupKey, MutableMap<Long, Array<Interval>>>()
 		for (entry in map)
 			mapByBlockKey.computeIfAbsent(getBlockKey(level, entry.key)) { mutableMapOf() } [entry.key] = entry.value
+		cache.invalidateIf { it.level == level }
 		mapByBlockKey.forEach(this::writeBlock)
 	}
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
@@ -1,43 +1,49 @@
 package org.janelia.saalfeldlab.labels.blocks.n5
 
-import gnu.trove.map.hash.TIntObjectHashMap
-import gnu.trove.map.hash.TLongObjectHashMap
 import net.imglib2.FinalInterval
 import net.imglib2.Interval
+import net.imglib2.cache.Invalidate
+import net.imglib2.cache.ref.SoftRefLoaderCache
 import net.imglib2.util.Intervals
+import org.janelia.saalfeldlab.labels.blocks.CachedLabelBlockLookup
 import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupKey
 import org.janelia.saalfeldlab.n5.*
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.lang.invoke.MethodHandles
 import java.nio.ByteBuffer
 import java.util.*
+import java.util.function.Predicate
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
 @LabelBlockLookup.LookupType("n5-filesystem")
 class LabelBlockLookupFromN5(
 		@LabelBlockLookup.Parameter private val root: String,
-		@LabelBlockLookup.Parameter private val scaleDatasetPattern: String) : LabelBlockLookup {
+		@LabelBlockLookup.Parameter private val scaleDatasetPattern: String) : CachedLabelBlockLookup {
 
 	private constructor(): this("", "")
 
 	private var n5: N5FSWriter? = null
+
+	private val attributes = mutableMapOf<Int, DatasetAttributes>()
+
+	private data class N5LabelBlockLookupKey(val level: Int, val blockId: Long)
+
+	private val cache = SoftRefLoaderCache<N5LabelBlockLookupKey, Map<Long, Array<Interval>>>()
 
 	companion object {
 		private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
 
 		private const val SINGLE_ENTRY_BYTE_SIZE = 3 * 2 * java.lang.Long.BYTES
 
-		private fun fromBytes(array: ByteArray): TLongObjectHashMap<Array<Interval>> {
-
-			val map = TLongObjectHashMap<Array<Interval>>()
-
+		private fun fromBytes(array: ByteArray): Map<Long, Array<Interval>> {
+			val map = mutableMapOf<Long, Array<Interval>>()
 			val bb = ByteBuffer.wrap(array)
 			while (bb.hasRemaining()) {
 				val id = bb.long
 				val numIntervals = bb.int
-
 				val intervals = Stream
 						.generate(
 								({
@@ -49,20 +55,19 @@ class LabelBlockLookupFromN5(
 						.limit(numIntervals.toLong())
 						.collect(Collectors.toList())
 						.toTypedArray()
-				map.put(id, intervals)
+				map[id] = intervals
 			}
-
-			return map
+			return map.toMap()
 		}
 
-		private fun toBytes(map: TLongObjectHashMap<Array<Interval>>): ByteArray {
-			val sizeInBytes = map.valueCollection().stream().mapToInt { java.lang.Long.BYTES + Integer.BYTES + SINGLE_ENTRY_BYTE_SIZE * it.size }.sum()
+		private fun toBytes(map: Map<Long, Array<Interval>>): ByteArray {
+			val sizeInBytes = map.values.stream().mapToInt { java.lang.Long.BYTES + Integer.BYTES + SINGLE_ENTRY_BYTE_SIZE * it.size }.sum()
 			val bytes = ByteArray(sizeInBytes)
 			val bb = ByteBuffer.wrap(bytes)
-			map.forEachEntry { key, value ->
-				bb.putLong(key)
-				bb.putInt(value.size)
-				for (interval in value) {
+			for (entry in map) {
+				bb.putLong(entry.key)
+				bb.putInt(entry.value.size)
+				for (interval in entry.value) {
 					bb.putLong(interval.min(0))
 					bb.putLong(interval.min(1))
 					bb.putLong(interval.min(2))
@@ -70,95 +75,79 @@ class LabelBlockLookupFromN5(
 					bb.putLong(interval.max(1))
 					bb.putLong(interval.max(2))
 				}
-				true
 			}
 			return bytes
 		}
 	}
 
-	private val attributes = mutableMapOf<Int, DatasetAttributes>()
+	override fun read(key: LabelBlockLookupKey): Array<Interval> {
+		val map = cache.get(getBlockKey(key), this::readBlock)
+		return map[key.id] ?: arrayOf()
+	}
 
-	private val cache = TIntObjectHashMap<TLongObjectHashMap<TLongObjectHashMap<Array<Interval>>>>() // scale -> block index -> id -> intervals
+	override fun write(key: LabelBlockLookupKey, vararg intervals: Interval) {
+		val blockKey = getBlockKey(key)
+		cache.invalidate(blockKey)
+		val map = readBlock(blockKey).toMutableMap()
+		map[key.id] = arrayOf(*intervals)
+		writeBlock(getBlockKey(key), map)
+	}
 
-	@Throws(IOException::class)
-	@Synchronized
-	fun set(level: Int, ids: TLongObjectHashMap<Array<Interval>>) {
-		val mapByBlock = mutableMapOf<Long, TLongObjectHashMap<Array<Interval>>>()
-		ids.forEachEntry { key, value ->
-			mapByBlock.computeIfAbsent(getBlockId(level, key)) { TLongObjectHashMap() }.put(key, value)
-			true
+	override fun invalidate(key: LabelBlockLookupKey) {
+		val blockKey = getBlockKey(key)
+		cache.invalidate(blockKey)
+	}
+
+	override fun invalidateAll(parallelismThreshold: Long) {
+		cache.invalidateAll(parallelismThreshold)
+	}
+
+	override fun invalidateIf(parallelismThreshold: Long, condition: Predicate<LabelBlockLookupKey>) {
+		val blockPredicate = Predicate<N5LabelBlockLookupKey> {
+			var ret = false
+			val map = cache.getIfPresent(it)
+			if (map != null) {
+				for (id in map.keys) {
+					if (condition.test(LabelBlockLookupKey(it.level, id))) {
+						ret = true
+						break
+					}
+				}
+			}
+			ret
 		}
-		for (m in mapByBlock)
-			writeAndCacheMap(level, m.key, m.value)
+		cache.invalidateIf(parallelismThreshold, blockPredicate)
 	}
 
 	@Throws(IOException::class)
-	@Synchronized
-	override fun read(level: Int, id: Long): Array<Interval> {
-		LOG.debug("Reading id {} for level={}", id, level)
-		val map = getMap(level, getBlockId(level, id))
-		return map.get(id)
+	fun set(level: Int, map: Map<Long, Array<Interval>>) {
+		val mapByBlockKey = mutableMapOf<N5LabelBlockLookupKey, MutableMap<Long, Array<Interval>>>()
+		for (entry in map)
+			mapByBlockKey.computeIfAbsent(getBlockKey(level, entry.key)) { mutableMapOf() } [entry.key] = entry.value
+		mapByBlockKey.forEach(this::writeBlock)
 	}
 
 	@Throws(IOException::class)
-	@Synchronized
-	override fun write(level: Int, id: Long, vararg intervals: Interval) {
-		val blockId = getBlockId(level, id)
-		val map = readAndCacheMap(level, blockId)
-		map.put(id, arrayOf(*intervals))
-		writeAndCacheMap(level, blockId, map)
-	}
+	private fun readBlock(blockKey: N5LabelBlockLookupKey): Map<Long, Array<Interval>> {
+		LOG.debug("Reading block id {} at scale level={}", blockKey.blockId, blockKey.level)
+		println("Reading block id " + blockKey.blockId + " at scale level " + blockKey.level)
 
-	@Synchronized
-	fun invalidateCache() {
-		cache.clear()
-	}
+		val dataset = "${String.format(scaleDatasetPattern, blockKey.level)}"
+		val attributes = this.attributes.getOrPut(blockKey.level, { n5().getDatasetAttributes(dataset) })
 
-	@Throws(IOException::class)
-	private fun getMap(level: Int, blockId: Long): TLongObjectHashMap<Array<Interval>> {
-		// check if map is already in the cache
-		if (cache.contains(level) && cache.get(level).contains(blockId))
-			return cache.get(level).get(blockId)
-
-		// not in the cache yet
-		return readAndCacheMap(level, blockId)
-	}
-
-	private fun cacheMap(level: Int, blockId: Long, map: TLongObjectHashMap<Array<Interval>>) {
-		if (!cache.contains(level))
-			cache.put(level, TLongObjectHashMap())
-		val cacheAtLevel = cache.get(level)
-
-		if (!cacheAtLevel.contains(blockId))
-			cacheAtLevel.put(blockId, TLongObjectHashMap())
-		val cacheAtLevelForBlock = cacheAtLevel.get(blockId)
-
-		cacheAtLevelForBlock.clear()
-		cacheAtLevelForBlock.putAll(map)
+		val block = n5().readBlock(dataset, attributes, longArrayOf(blockKey.blockId)) as? ByteArrayDataBlock
+		return if (block != null) fromBytes(block.data) else mapOf()
 	}
 
 	@Throws(IOException::class)
-	private fun readAndCacheMap(level: Int, blockId: Long): TLongObjectHashMap<Array<Interval>> {
-		val dataset = "${String.format(scaleDatasetPattern, level)}"
-		val attributes = this.attributes.getOrPut(level, { n5().getDatasetAttributes(dataset) })
-
-		val block = n5().readBlock(dataset, attributes, longArrayOf(blockId)) as? ByteArrayDataBlock
-		val map = if (block != null) fromBytes(block.data) else TLongObjectHashMap()
-
-		cacheMap(level, blockId, map)
-		return map
-	}
-
-	@Throws(IOException::class)
-	private fun writeAndCacheMap(level: Int, blockId: Long, map: TLongObjectHashMap<Array<Interval>>) {
-		val dataset = "${String.format(scaleDatasetPattern, level)}"
-		val attributes = this.attributes.getOrPut(level, { n5().getDatasetAttributes(dataset) })
+	private fun writeBlock(blockKey: N5LabelBlockLookupKey, map: Map<Long, Array<Interval>>) {
+		LOG.debug("Writing block id {} at scale level={}", blockKey.blockId, blockKey.level)
+		val dataset = "${String.format(scaleDatasetPattern, blockKey.level)}"
+		val attributes = this.attributes.getOrPut(blockKey.level, { n5().getDatasetAttributes(dataset) })
 
 		val size = intArrayOf(attributes.blockSize[0])
-		val block = ByteArrayDataBlock(size, longArrayOf(blockId), toBytes(map))
-
+		val block = ByteArrayDataBlock(size, longArrayOf(blockKey.blockId), toBytes(map))
 		n5().writeBlock(dataset, attributes, block)
-		cacheMap(level, blockId, map)
 	}
 
 	@Throws(IOException::class)
@@ -168,11 +157,16 @@ class LabelBlockLookupFromN5(
 		return n5!!
 	}
 
-	private fun getBlockId(level: Int, id: Long): Long {
+	private fun getBlockKey(key: LabelBlockLookupKey): N5LabelBlockLookupKey {
+		return getBlockKey(key.level, key.id)
+	}
+
+	private fun getBlockKey(level: Int, id: Long): N5LabelBlockLookupKey {
 		val dataset = "${String.format(scaleDatasetPattern, level)}"
 		val attributes = this.attributes.getOrPut(level, { n5().getDatasetAttributes(dataset) })
 		val blockSize = attributes.blockSize[0]
-		return id / blockSize
+		val blockId = id / blockSize
+		return N5LabelBlockLookupKey(level, blockId)
 	}
 }
 
@@ -185,13 +179,13 @@ fun main(args: Array<String>) {
 
 	writer.createDataset(String.format(pattern, level), DatasetAttributes(longArrayOf(100), intArrayOf(3), DataType.INT8, GzipCompression()))
 
-	val map = TLongObjectHashMap<Array<Interval>>()
-	map.put(1L, arrayOf(FinalInterval(longArrayOf(1, 2, 3), longArrayOf(3, 4, 5)) as Interval))
+	val map = mutableMapOf<Long, Array<Interval>>()
+	map[1L] = arrayOf(FinalInterval(longArrayOf(1, 2, 3), longArrayOf(3, 4, 5)) as Interval)
 
 	lookup.set(level, map)
-	lookup.write(level, 10L, FinalInterval(longArrayOf(4, 5, 6), longArrayOf(7, 8, 9)) as Interval, FinalInterval(longArrayOf(10, 11, 12), longArrayOf(123, 123, 123)))
-	lookup.write(level, 0L, FinalInterval(longArrayOf(1, 1, 1), longArrayOf(2, 2, 2)))
+	lookup.write(LabelBlockLookupKey(level, 10L), FinalInterval(longArrayOf(4, 5, 6), longArrayOf(7, 8, 9)) as Interval, FinalInterval(longArrayOf(10, 11, 12), longArrayOf(123, 123, 123)))
+	lookup.write(LabelBlockLookupKey(level, 0L), FinalInterval(longArrayOf(1, 1, 1), longArrayOf(2, 2, 2)))
 
 	for (i in 0L..11L)
-		println(lookup.read(level, i).asList().stream().map { "(${Arrays.toString(Intervals.minAsLongArray(it))}-${Arrays.toString(Intervals.maxAsLongArray(it))})" }.collect(Collectors.toList()) as List<String>)
+		println(lookup.read(LabelBlockLookupKey(level, i)).asList().stream().map { "(${Arrays.toString(Intervals.minAsLongArray(it))}-${Arrays.toString(Intervals.maxAsLongArray(it))})" }.collect(Collectors.toList()) as List<String>)
 }

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
@@ -150,7 +150,7 @@ class LabelBlockLookupFromN5(
 	private fun getBlockKey(key: LabelBlockLookupKey) = getBlockKey(key.level, key.id)
 
 	private fun getBlockKey(level: Int, id: Long): N5LabelBlockLookupKey {
-		val dataset = "${String.format(scaleDatasetPattern, level)}"
+		val dataset = String.format(scaleDatasetPattern, level)
 		val attributes = this.attributes.getOrPut(level, { n5().getDatasetAttributes(dataset) })
 		val blockSize = attributes.blockSize[0]
 		val blockId = id / blockSize

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
@@ -31,6 +31,7 @@ class LabelBlockLookupFromN5(
 
 	private data class N5LabelBlockLookupKey(val level: Int, val blockId: Long)
 
+	// Cache all lookups in a block when it's requested for the first time
 	private val cache = SoftRefLoaderCache<N5LabelBlockLookupKey, Map<Long, Array<Interval>>>()
 
 	companion object {

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
@@ -81,11 +81,13 @@ class LabelBlockLookupFromN5(
 		}
 	}
 
+	@Synchronized
 	override fun read(key: LabelBlockLookupKey): Array<Interval> {
 		val map = cache.get(getBlockKey(key), this::readBlock)
 		return map[key.id] ?: arrayOf()
 	}
 
+	@Synchronized
 	override fun write(key: LabelBlockLookupKey, vararg intervals: Interval) {
 		val blockKey = getBlockKey(key)
 		cache.invalidate(blockKey)
@@ -94,16 +96,20 @@ class LabelBlockLookupFromN5(
 		writeBlock(getBlockKey(key), map)
 	}
 
+	@Synchronized
 	override fun invalidate(key: LabelBlockLookupKey) = cache.invalidate(getBlockKey(key))
 
+	@Synchronized
 	override fun invalidateAll(parallelismThreshold: Long) = cache.invalidateAll(parallelismThreshold)
 
+	@Synchronized
 	override fun invalidateIf(parallelismThreshold: Long, condition: Predicate<LabelBlockLookupKey>) {
 		cache.invalidateIf(parallelismThreshold) { key ->
 			cache.getIfPresent(key)?.keys?.any { id -> condition.test(LabelBlockLookupKey(key.level, id)) } ?: false
 		}
 	}
 
+	@Synchronized
 	@Throws(IOException::class)
 	fun set(level: Int, map: Map<Long, Array<Interval>>) {
 		val mapByBlockKey = mutableMapOf<N5LabelBlockLookupKey, MutableMap<Long, Array<Interval>>>()


### PR DESCRIPTION
This PR allows to speed up label-to-block lookups. The gain comes from caching the loaded data for other labels that are stored in the same data block.

For example, if you request `read(level, id1)` and then make a subsequent request `read(level, id2)`, it wouldn't need to re-read the data block file the second time (if the block lists for the labels `id1` and `id2` are stored in the same data block file).

This significantly improves initial 3D scene rendering performance in https://github.com/saalfeldlab/paintera/pull/267 when selecting a very large set of objects, for example, with `Ctrl+A` or `Ctrl+Shift+A`.