### PR TITLE
Add new lookup that is relative to a container and group.

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/IsRelativeToContainer.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/IsRelativeToContainer.kt
@@ -1,0 +1,7 @@
+package org.janelia.saalfeldlab.labels.blocks.n5
+
+interface IsRelativeToContainer {
+
+    fun setRelativeTo(container: String, group: String? = null)
+
+}

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt
@@ -2,23 +2,23 @@ package org.janelia.saalfeldlab.labels.blocks.n5
 
 import net.imglib2.FinalInterval
 import net.imglib2.Interval
-import net.imglib2.cache.Invalidate
 import net.imglib2.cache.ref.SoftRefLoaderCache
-import net.imglib2.util.Intervals
 import org.janelia.saalfeldlab.labels.blocks.CachedLabelBlockLookup
 import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup
 import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupKey
-import org.janelia.saalfeldlab.n5.*
+import org.janelia.saalfeldlab.n5.ByteArrayDataBlock
+import org.janelia.saalfeldlab.n5.DatasetAttributes
+import org.janelia.saalfeldlab.n5.N5FSWriter
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.lang.invoke.MethodHandles
 import java.nio.ByteBuffer
 import java.util.*
 import java.util.function.Predicate
-import java.util.stream.Collectors
-import java.util.stream.Stream
 
-@LabelBlockLookup.LookupType("n5-filesystem")
+private const val LOOKUP_TYPE_IDENTIFIER = "n5-filesystem"
+
+@LabelBlockLookup.LookupType(LOOKUP_TYPE_IDENTIFIER)
 class LabelBlockLookupFromN5(
 		@LabelBlockLookup.Parameter private val root: String,
 		@LabelBlockLookup.Parameter private val scaleDatasetPattern: String) : CachedLabelBlockLookup {
@@ -36,6 +36,8 @@ class LabelBlockLookupFromN5(
 
 	companion object {
 		private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+
+		const val LOOKUP_TYPE = LOOKUP_TYPE_IDENTIFIER
 
 		private const val SINGLE_ENTRY_BYTE_SIZE = 3 * 2 * java.lang.Long.BYTES
 
@@ -102,6 +104,12 @@ class LabelBlockLookupFromN5(
 			cache.getIfPresent(key)?.keys?.any { id -> condition.test(LabelBlockLookupKey(key.level, id)) } ?: false
 		}
 	}
+
+	override fun equals(other: Any?) = other is LabelBlockLookupFromN5
+			&& other.scaleDatasetPattern == scaleDatasetPattern
+			&& other.root == root
+
+	override fun hashCode() = Objects.hash(root, scaleDatasetPattern)
 
 	@Synchronized
 	@Throws(IOException::class)

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5Relative.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5Relative.kt
@@ -1,0 +1,172 @@
+package org.janelia.saalfeldlab.labels.blocks.n5
+
+import net.imglib2.FinalInterval
+import net.imglib2.Interval
+import net.imglib2.cache.ref.SoftRefLoaderCache
+import org.janelia.saalfeldlab.labels.blocks.CachedLabelBlockLookup
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupKey
+import org.janelia.saalfeldlab.n5.ByteArrayDataBlock
+import org.janelia.saalfeldlab.n5.DatasetAttributes
+import org.janelia.saalfeldlab.n5.N5FSWriter
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.lang.invoke.MethodHandles
+import java.nio.ByteBuffer
+import java.util.function.Predicate
+
+private const val LOOKUP_TYPE_IDENTIFIER = "n5-filesystem-relative"
+
+@LabelBlockLookup.LookupType(LOOKUP_TYPE_IDENTIFIER)
+class LabelBlockLookupFromN5Relative(
+        @LabelBlockLookup.Parameter private val scaleDatasetPattern: String) : CachedLabelBlockLookup, IsRelativeToContainer {
+
+    private constructor() : this("")
+
+    private lateinit var n5: N5FSWriter
+
+    private lateinit var _container: String
+
+    var container: String
+        get() = _container
+        private set(container) {
+            _container = container
+            n5 = N5FSWriter(_container)
+        }
+
+    private var group: String? = null
+
+    private val actualScaleDatasetPattern: String
+        get() = group?.let { "$it/$scaleDatasetPattern" } ?: scaleDatasetPattern
+
+    private val attributes = mutableMapOf<Int, DatasetAttributes>()
+
+    private data class N5LabelBlockLookupKey(val level: Int, val blockId: Long)
+
+    // Cache all lookups in a block when it's requested for the first time
+    private val cache = SoftRefLoaderCache<N5LabelBlockLookupKey, Map<Long, Array<Interval>>>()
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+
+        const val LOOKUP_TYPE = LOOKUP_TYPE_IDENTIFIER
+
+        private const val SINGLE_ENTRY_BYTE_SIZE = 3 * 2 * java.lang.Long.BYTES
+
+        private fun fromBytes(array: ByteArray): MutableMap<Long, Array<Interval>> {
+            val map = mutableMapOf<Long, Array<Interval>>()
+            val bb = ByteBuffer.wrap(array)
+            while (bb.hasRemaining()) {
+                val id = bb.long
+                val numIntervals = bb.int
+                map[id] = (0 until numIntervals).map<Int, Interval> { bb.readFinalInterval3D() }.toTypedArray()
+            }
+            return map
+        }
+
+        private fun toBytes(map: Map<Long, Array<Interval>>): ByteArray {
+            val sizeInBytes = map.values.stream().mapToInt { java.lang.Long.BYTES + Integer.BYTES + SINGLE_ENTRY_BYTE_SIZE * it.size }.sum()
+            val bytes = ByteArray(sizeInBytes)
+            val bb = ByteBuffer.wrap(bytes)
+            for (entry in map) {
+                bb.putLong(entry.key)
+                bb.putInt(entry.value.size)
+                entry.value.forEach { bb.writeInterval3D(it) }
+            }
+            return bytes
+        }
+
+        private fun ByteBuffer.readLongArray3D() = longArrayOf(long, long, long)
+        private fun ByteBuffer.readFinalInterval3D() = FinalInterval(readLongArray3D(), readLongArray3D())
+        private inline fun ByteBuffer.writeThreeLongValues(generator: (Int) -> Long) {
+            putLong(generator(0))
+            putLong(generator(1))
+            putLong(generator(2))
+        }
+
+        private fun ByteBuffer.writeInterval3D(interval: Interval) {
+            writeThreeLongValues { interval.min(it) }
+            writeThreeLongValues { interval.max(it) }
+        }
+    }
+
+    @Synchronized
+    override fun read(key: LabelBlockLookupKey): Array<Interval> {
+        val map = cache.get(getBlockKey(key), this::readBlock)
+        return map[key.id] ?: arrayOf()
+    }
+
+    @Synchronized
+    override fun write(key: LabelBlockLookupKey, vararg intervals: Interval) {
+        val blockKey = getBlockKey(key)
+        cache.invalidate(blockKey)
+        val map = readBlock(blockKey)
+        map[key.id] = arrayOf(*intervals)
+        writeBlock(getBlockKey(key), map)
+    }
+
+    @Synchronized
+    override fun invalidate(key: LabelBlockLookupKey) = cache.invalidate(getBlockKey(key))
+
+    @Synchronized
+    override fun invalidateAll(parallelismThreshold: Long) = cache.invalidateAll(parallelismThreshold)
+
+    @Synchronized
+    override fun invalidateIf(parallelismThreshold: Long, condition: Predicate<LabelBlockLookupKey>) {
+        cache.invalidateIf(parallelismThreshold) { key ->
+            cache.getIfPresent(key)?.keys?.any { id -> condition.test(LabelBlockLookupKey(key.level, id)) } ?: false
+        }
+    }
+
+    @Synchronized
+    @Throws(IOException::class)
+    fun set(level: Int, map: Map<Long, Array<Interval>>) {
+        val mapByBlockKey = mutableMapOf<N5LabelBlockLookupKey, MutableMap<Long, Array<Interval>>>()
+        for (entry in map)
+            mapByBlockKey.computeIfAbsent(getBlockKey(level, entry.key)) { mutableMapOf() }[entry.key] = entry.value
+        cache.invalidateIf { it.level == level }
+        mapByBlockKey.forEach(this::writeBlock)
+    }
+
+    @Throws(IOException::class)
+    private fun readBlock(blockKey: N5LabelBlockLookupKey): MutableMap<Long, Array<Interval>> {
+        LOG.debug("Reading block id {} at scale level={}", blockKey.blockId, blockKey.level)
+        val dataset = String.format(actualScaleDatasetPattern, blockKey.level)
+        val attributes = this.attributes.getOrPut(blockKey.level, { n5.getDatasetAttributes(dataset) })
+
+        val block = n5.readBlock(dataset, attributes, longArrayOf(blockKey.blockId)) as? ByteArrayDataBlock
+        return if (block != null) fromBytes(block.data) else mutableMapOf()
+    }
+
+    @Throws(IOException::class)
+    private fun writeBlock(blockKey: N5LabelBlockLookupKey, map: Map<Long, Array<Interval>>) {
+        LOG.debug("Writing block id {} at scale level={}", blockKey.blockId, blockKey.level)
+        val dataset = String.format(actualScaleDatasetPattern, blockKey.level)
+        val attributes = this.attributes.getOrPut(blockKey.level, { n5.getDatasetAttributes(dataset) })
+
+        val size = intArrayOf(attributes.blockSize[0])
+        val block = ByteArrayDataBlock(size, longArrayOf(blockKey.blockId), toBytes(map))
+        n5.writeBlock(dataset, attributes, block)
+    }
+
+    private fun getBlockKey(key: LabelBlockLookupKey) = getBlockKey(key.level, key.id)
+
+    private fun getBlockKey(level: Int, id: Long): N5LabelBlockLookupKey {
+        val dataset = String.format(actualScaleDatasetPattern, level)
+        val attributes = this.attributes.getOrPut(level, { n5.getDatasetAttributes(dataset) })
+        val blockSize = attributes.blockSize[0]
+        val blockId = id / blockSize
+        return N5LabelBlockLookupKey(level, blockId)
+    }
+
+    override fun setRelativeTo(container: String, group: String?) {
+        this.container = container
+        this.group = group
+    }
+
+    override fun equals(other: Any?) = other is LabelBlockLookupFromN5Relative
+            && other.scaleDatasetPattern == scaleDatasetPattern
+
+    override fun hashCode() = scaleDatasetPattern.hashCode()
+
+}

--- a/src/test/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5RelativeTest.kt
+++ b/src/test/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5RelativeTest.kt
@@ -1,0 +1,155 @@
+package org.janelia.saalfeldlab.labels.blocks.n5
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonObject
+import net.imglib2.Interval
+import net.imglib2.util.Intervals
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupAdapter
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupKey
+import org.janelia.saalfeldlab.n5.DataType
+import org.janelia.saalfeldlab.n5.DatasetAttributes
+import org.janelia.saalfeldlab.n5.GzipCompression
+import org.janelia.saalfeldlab.n5.N5FSWriter
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.Test
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.lang.invoke.MethodHandles
+
+class LabelBlockLookupFromN5RelativeTest {
+
+    @Test(expected = UninitializedPropertyAccessException::class)
+    fun `test uninitialized for LabelBlockLookupFromN5Relative`() {
+        LabelBlockLookupFromN5Relative("s%d").read(LabelBlockLookupKey(0, 0))
+    }
+
+    @Test
+    fun `test serialization for LabelBlockLookupFromN5Relative`() {
+        Assert.assertEquals("n5-filesystem-relative", LabelBlockLookupFromN5Relative.LOOKUP_TYPE)
+
+        val pattern1 = "1/s%d"
+        val pattern2 = "2/s%d"
+        val lookup1 = LabelBlockLookupFromN5Relative(pattern1)
+        val lookup2 = LabelBlockLookupFromN5Relative(pattern2)
+
+        Assert.assertEquals(lookup1, LabelBlockLookupFromN5Relative(pattern1))
+        Assert.assertEquals(lookup2, LabelBlockLookupFromN5Relative(pattern2))
+        Assert.assertNotEquals(lookup1, lookup2)
+
+        val gson = GsonBuilder()
+                .registerTypeHierarchyAdapter(LabelBlockLookup::class.java, LabelBlockLookupAdapter.getJsonAdapter())
+                .create()
+
+        val serialized1 = gson.toJsonTree(lookup1)
+        val serialized2 = gson.toJsonTree(lookup2)
+
+        Assert.assertEquals(
+                JsonObject()
+                        .also { it.addProperty("type", LabelBlockLookupFromN5Relative.LOOKUP_TYPE) }
+                        .also { it.addProperty("scaleDatasetPattern", pattern1) },
+                serialized1)
+        Assert.assertEquals(
+                JsonObject()
+                        .also { it.addProperty("type", LabelBlockLookupFromN5Relative.LOOKUP_TYPE) }
+                        .also { it.addProperty("scaleDatasetPattern", pattern2) },
+                serialized2)
+
+        val deserialized1 = gson.fromJson(serialized1, LabelBlockLookup::class.java)
+        val deserialized2 = gson.fromJson(serialized2, LabelBlockLookup::class.java)
+
+        Assert.assertEquals(lookup1, deserialized1)
+        Assert.assertEquals(lookup2, deserialized2)
+    }
+
+    @Test
+    fun `test LabelBlockLookupFromN5Relative`() {
+        val containerPath = testDirectory.resolve("container.n5").absolutePath
+        LOG.debug("container={}", containerPath)
+
+        for (group in arrayOf("group", null)) {
+
+            val level = 1
+            val pattern = "label-to-block-mapping/s%d"
+            val writer = N5FSWriter(containerPath)
+            val lookup = LabelBlockLookupFromN5Relative(pattern)
+            val dataset = String.format(group?.let { "$it/$pattern" } ?: pattern, level)
+            lookup.setRelativeTo(containerPath, group)
+
+            writer.createDataset(dataset, DatasetAttributes(longArrayOf(100), intArrayOf(3), DataType.INT8, GzipCompression()))
+
+            val map = mutableMapOf<Long, Array<Interval>>()
+            val intervalsForId1 = arrayOf<Interval>(Intervals.createMinMax(1, 2, 3, 3, 4, 5))
+            map[1L] = intervalsForId1
+
+            val intervalsForId0 = arrayOf<Interval>(Intervals.createMinMax(1, 1, 1, 2, 2, 2))
+            val intervalsForId10 = arrayOf<Interval>(
+                    Intervals.createMinMax(4, 5, 6, 7, 8, 9),
+                    Intervals.createMinMax(10, 11, 12, 123, 123, 123))
+
+
+            lookup.set(level, map)
+            lookup.write(LabelBlockLookupKey(level, 10L), *intervalsForId10)
+            lookup.write(LabelBlockLookupKey(level, 0L), *intervalsForId0)
+
+            val groundTruthMap = mapOf(
+                    Pair(0L, intervalsForId0),
+                    Pair(1L, intervalsForId1),
+                    Pair(10L, intervalsForId10))
+
+            for (i in 0L..11L) {
+                val intervals = lookup.read(LabelBlockLookupKey(level, i))
+                val groundTruth = groundTruthMap[i] ?: arrayOf()
+                LOG.debug("Block {}: Got intervals {}", i, intervals)
+                Assert.assertEquals("Size Mismatch for index $i", groundTruth.size, intervals.size)
+                (groundTruth zip intervals).forEachIndexed { idx, p ->
+                    Assert.assertThat(
+                            "Mismatch for interval $idx of entry $i",
+                            p.second,
+                            IntervalMatcher(p.first))
+                }
+            }
+        }
+    }
+
+    companion object {
+
+        private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())
+
+        private lateinit var _testDirectory: File
+
+        private val testDirectory: File
+            get() {
+                if (!::_testDirectory.isInitialized)
+                    _testDirectory = tempDirectory()
+                return _testDirectory
+            }
+
+        private val isDeleteOnExit: Boolean
+            get() = !LOG.isDebugEnabled
+
+        @AfterClass
+        @JvmStatic
+        fun deleteTestDirectory() {
+            if (isDeleteOnExit && ::_testDirectory.isInitialized)
+                testDirectory.deleteRecursively()
+        }
+
+        private fun tempDirectory(
+                prefix: String = "label-utilities-n5-",
+                suffix: String? = ".test") = createTempDir(prefix, suffix).also { LOG.debug("Created tmp directory {}", it) }
+
+    }
+
+    private class IntervalMatcher(private val interval: Interval) : TypeSafeMatcher<Interval>() {
+
+        override fun describeTo(description: Description?) = description?.appendValue(interval).let {}
+
+        override fun matchesSafely(item: Interval?) = item?.let { Intervals.equals(interval, it) } ?: false
+
+    }
+
+}

--- a/src/test/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5Test.kt
+++ b/src/test/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5Test.kt
@@ -1,9 +1,13 @@
 package org.janelia.saalfeldlab.labels.blocks.n5
 
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonObject
 import net.imglib2.Interval
 import net.imglib2.util.Intervals
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookup
+import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupAdapter
 import org.janelia.saalfeldlab.labels.blocks.LabelBlockLookupKey
 import org.janelia.saalfeldlab.n5.DataType
 import org.janelia.saalfeldlab.n5.DatasetAttributes
@@ -17,6 +21,48 @@ import java.io.File
 import java.lang.invoke.MethodHandles
 
 class LabelBlockLookupFromN5Test {
+
+    @Test
+    fun `test serialization for LabelBlockLookupFromN5`() {
+        Assert.assertEquals("n5-filesystem", LabelBlockLookupFromN5.LOOKUP_TYPE)
+
+        val pattern1 = "1/s%d"
+        val pattern2 = "2/s%d"
+        val container1 = "c1.n5"
+        val container2 = "c2.n5"
+        val lookup1 = LabelBlockLookupFromN5(container1, pattern1)
+        val lookup2 = LabelBlockLookupFromN5(container2, pattern2)
+
+        Assert.assertEquals(lookup1, LabelBlockLookupFromN5(container1, pattern1))
+        Assert.assertEquals(lookup2, LabelBlockLookupFromN5(container2, pattern2))
+        Assert.assertNotEquals(lookup1, lookup2)
+
+        val gson = GsonBuilder()
+                .registerTypeHierarchyAdapter(LabelBlockLookup::class.java, LabelBlockLookupAdapter.getJsonAdapter())
+                .create()
+
+        val serialized1 = gson.toJsonTree(lookup1)
+        val serialized2 = gson.toJsonTree(lookup2)
+
+        Assert.assertEquals(
+                JsonObject()
+                        .also { it.addProperty("type", LabelBlockLookupFromN5.LOOKUP_TYPE) }
+                        .also { it.addProperty("scaleDatasetPattern", pattern1) }
+                        .also { it.addProperty("root", container1) },
+                serialized1)
+        Assert.assertEquals(
+                JsonObject()
+                        .also { it.addProperty("type", LabelBlockLookupFromN5.LOOKUP_TYPE) }
+                        .also { it.addProperty("scaleDatasetPattern", pattern2) }
+                        .also { it.addProperty("root", container2) },
+                serialized2)
+
+        val deserialized1 = gson.fromJson(serialized1, LabelBlockLookup::class.java)
+        val deserialized2 = gson.fromJson(serialized2, LabelBlockLookup::class.java)
+
+        Assert.assertEquals(lookup1, deserialized1)
+        Assert.assertEquals(lookup2, deserialized2)
+    }
 
     @Test
     fun `test LabelBlockLookupFromN5`() {


### PR DESCRIPTION
This is the first step for providing data sources that can be stored in relative locations.

This should be a replacement for https://github.com/saalfeldlab/label-utilities/pull/8