### PR TITLE
Improve IsRelativeToContainer interface

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/IsRelativeToContainer.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/IsRelativeToContainer.kt
@@ -1,7 +1,9 @@
 package org.janelia.saalfeldlab.labels.blocks.n5
 
+import org.janelia.saalfeldlab.n5.N5Writer
+
 interface IsRelativeToContainer {
 
-    fun setRelativeTo(container: String, group: String? = null)
+    fun setRelativeTo(container: N5Writer, group: String? = null)
 
 }

--- a/src/test/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5RelativeTest.kt
+++ b/src/test/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5RelativeTest.kt
@@ -77,7 +77,7 @@ class LabelBlockLookupFromN5RelativeTest {
             val writer = N5FSWriter(containerPath)
             val lookup = LabelBlockLookupFromN5Relative(pattern)
             val dataset = String.format(group?.let { "$it/$pattern" } ?: pattern, level)
-            lookup.setRelativeTo(containerPath, group)
+            lookup.setRelativeTo(writer, group)
 
             writer.createDataset(dataset, DatasetAttributes(longArrayOf(100), intArrayOf(3), DataType.INT8, GzipCompression()))
 


### PR DESCRIPTION
Passing `N5Writer` instead of `String` `setRelativeTo` makes more sense.

This should be a considered a bugfix.